### PR TITLE
LRDOCS-2928 Markeptlace: Remove Liferay Only in Submitting Your Apps

### DIFF
--- a/distribute/publish/articles/01-publishing-your-app/03-submitting-your-app.markdown
+++ b/distribute/publish/articles/01-publishing-your-app/03-submitting-your-app.markdown
@@ -106,13 +106,6 @@ for detailed requirements for tags.
 **EULA:** You can use the default end user license agreement (EULA) or provide
 your own. There's a link to the minimum terms which custom EULAs must satisfy.
 
-**Liferay Only:** If you're publishing a CE-only or EE-only app, select 
-*CE Only* or *EE Only* in the *Product Type* selector. If you're providing an
-app that runs on both CE and EE, just flag the *Liferay EE Plugin* check box. If
-you're uploading a bug fix or would like to replace a previous version of your
-app, specify the app entry IDs of the apps to be replaced by the new app in the
-*Supercedes App Entry IDs* field.
-
 Remember to visit the articles
 [Planning Your App's Distribution](/distribute/how-to-publish/-/knowledge_base/how-to-publish/planning-your-apps-distribution)
 and


### PR DESCRIPTION
One of our documentation has informations in which is only relevant to Liferay within our Submitting Your Apps (https://dev.liferay.com/distribute/how-to-publish/-/knowledge_base/how-to-publish/submitting-your-app).

I have created a ticket to take care of this (https://issues.liferay.com/browse/LRDOCS-2928) and this is the pull request in which shall take care of the problem.

Please review my pull request!

Thank you!