### PR TITLE
Remove DDL Form from app deprecation list

### DIFF
--- a/discover/deployment/articles/06-upgrading-to-liferay-7-1/99-deprecated-apps.markdown
+++ b/discover/deployment/articles/06-upgrading-to-liferay-7-1/99-deprecated-apps.markdown
@@ -90,13 +90,7 @@ availability.
 
 | App | &nbsp;Availability | &nbsp;Notes |
 | --- | ------------------ | ----------- |
-| Dynamic Data List Form | Removed* |  |
 | Web Form | Nexus &rarr; Will be removed. | Final version released for 7.0. |
-
-The Dynamic Data List Form application is removed from @product-ver@, but its
-code now lives in another module, Dynamic Data Mapping Form. Therefore, the
-Liferay Forms application present in the previous version is still present, with 
-[lots of improvements](/discover/portal/-/knowledge_base/7-1/whats-new-with-liferay-forms).
 
 ## Security [](id=security)
 

--- a/discover/deployment/articles/06-upgrading-to-liferay-7-1/99-deprecated-apps.markdown
+++ b/discover/deployment/articles/06-upgrading-to-liferay-7-1/99-deprecated-apps.markdown
@@ -90,8 +90,13 @@ availability.
 
 | App | &nbsp;Availability | &nbsp;Notes |
 | --- | ------------------ | ----------- |
-| Dynamic Data List Form | Removed |  |
+| Dynamic Data List Form | Removed* |  |
 | Web Form | Nexus &rarr; Will be removed. | Final version released for 7.0. |
+
+The Dynamic Data List Form application is removed from @product-ver@, but its
+code now lives in another module, Dynamic Data Mapping Form. Therefore, the
+Liferay Forms application present in the previous version is still present, with 
+[lots of improvements](/discover/portal/-/knowledge_base/7-1/whats-new-with-liferay-forms).
 
 ## Security [](id=security)
 


### PR DESCRIPTION
Dynamic Data List Form code was removed in favor of the DDM Form modules, but it's not really app deprecation because the application is sitll available just as it was in 7.0 (with improvements). Instead we'll mention this in our dev guide section, because it applies to folks looking in the code. cc @natocesarrego